### PR TITLE
update `link_to_delete_fields` example to use params hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Add to the partial only the fields you want to edit like this:
 .fields
   = fields.label :field1
   = fields.text_field :field1
-  
+
   = fields.label :field2
   = fields.text_field :field2
-  
-  = link_to_delete_fields fields, "Delete"
+
+  = link_to_delete_fields fields, name: "Delete"
 ```
 
 The "link_to_delete_fields" helper is a easy way to make the nested fields deletable. You can put whatever divs/fieldsets etc. around those fields to style them.


### PR DESCRIPTION
The README had wrong syntax for `link_to_delete_fields`. 